### PR TITLE
fix: hide blue strip below apply-jobs screenshot frame

### DIFF
--- a/templates/landing/sections/apply_jobs.html
+++ b/templates/landing/sections/apply_jobs.html
@@ -101,7 +101,7 @@
       </div>
 
       <!-- Right: Application screenshot with cycling step images -->
-      <div id="apply-images" class="w-full md:w-[50%] xl:w-[498px] md:min-h-[704px] rounded-[12px] shadow-[0px_4px_8px_0px_rgba(0,0,0,0.5)] reveal reveal-delay-2 relative overflow-hidden">
+      <div id="apply-images" class="w-full md:w-[50%] xl:w-[498px] md:min-h-[704px] bg-white rounded-[12px] shadow-[0px_4px_8px_0px_rgba(0,0,0,0.5)] reveal reveal-delay-2 relative overflow-hidden">
         <!-- Step images (cycle based on active accordion) -->
         <img data-step-img="0" src="{{ url_for('static', filename='img/landing/apply-step-resume.gif') }}" alt="Submit Resume" class="apply-step-img rounded-[12px] w-full h-full object-cover">
         <img data-step-img="1" src="{{ url_for('static', filename='img/landing/apply-step-guidelines.gif') }}" alt="Review Guidelines" class="apply-step-img rounded-[12px] w-full h-full object-cover hidden">


### PR DESCRIPTION
## Summary
- Adds `bg-white` to the `#apply-images` frame in `templates/landing/sections/apply_jobs.html` so any leftover space at the bottom of the rounded screenshot frame reads as white instead of the section's light-blue `#EDF8FF` background.

## Why
The frame has `md:min-h-[704px]`, but the GIF inside uses `h-full` against a parent with only a *min-height*. Percentage height needs a definite parent height to resolve, so the image collapses to its intrinsic aspect-ratio height (shorter than 704px) and the min-height stretches the frame past it. That gap exposed the section's `bg-landing-light` background, which read as a blue strip beneath the rounded screenshot. The existing `rounded-[12px]` + `overflow-hidden` keep the new white fill clipped to the frame's rounded corners.

## Test plan
- [ ] Load `/` on desktop (>= md) and scroll to the "How to Find Your Dream Job" section. The screenshot frame on the right should appear as one continuous white rounded rectangle — no blue strip beneath the GIF.
- [ ] Cycle the accordion steps and confirm each GIF still swaps in without revealing the strip.
- [ ] Confirm the small white icon overlay in the top-left of the frame still looks correct (it has its own white background so this should be unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
